### PR TITLE
Identify ACS year for NYCgov poverty measure indicator in tooltip

### DIFF
--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -226,7 +226,7 @@
           {{#data.indicator class="indicator" name='NYCgov Poverty Measure'
                             column='poverty_rate'
                             moe='moe_poverty_rate'
-                            tip='NYC-specific poverty measure, adjusted for the City’s high cost of housing. Includes the value of anti-poverty programs (e.g. SNAP, housing assistance) as family resources. Accounts for certain costs (e.g. medical, commuting, childcare). Historically produces a higher, more realistic measure of poverty than the official U.S. measure.'
+                            tip='NYC-specific poverty measure, adjusted for the City’s high cost of housing. Includes the value of anti-poverty programs (e.g. SNAP, housing assistance) as family resources. Accounts for certain costs (e.g. medical, commuting, childcare). Historically produces a higher, more realistic measure of poverty than the official U.S. measure. Community district rates based on American Community Survey 2011-2015 5-Year Estimates; NYC and borough rates based on 2015 1-year estimates.'
                             unit='%'
                             cd_stat=d.poverty_rate
                             boro_stat=d.poverty_rate_boro


### PR DESCRIPTION
A user emailed the portal_dl to ask what year the NYCgov poverty indicator represented. The tooltip should include that information, as it does for ACS indicators.
