### PR TITLE
Clarify NYCgov poverty source in tooltip

### DIFF
--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -226,7 +226,7 @@
           {{#data.indicator class="indicator" name='NYCgov Poverty Measure'
                             column='poverty_rate'
                             moe='moe_poverty_rate'
-                            tip='NYC-specific poverty measure, adjusted for the City’s high cost of housing. Includes the value of anti-poverty programs (e.g. SNAP, housing assistance) as family resources. Accounts for certain costs (e.g. medical, commuting, childcare). Historically produces a higher, more realistic measure of poverty than the official U.S. measure.'
+                            tip='NYCgov Poverty Rate, 2011-2015 5-year average. This NYC-specific poverty measure is adjusted for the City’s high cost of housing and includes the value of anti-poverty programs (e.g. SNAP, housing assistance) as family resources. Accounts for certain costs (e.g. medical, commuting, childcare). Historically produces a higher, more realistic measure of poverty than the official U.S. measure.'
                             unit='%'
                             cd_stat=d.poverty_rate
                             boro_stat=d.poverty_rate_boro


### PR DESCRIPTION
This PR clarifies the source of the NYCgov Poverty Rate indicator. Unlike the ACS tooltips, this tooltip did not specify the years represented by the data.

The tooltip now says the data are from the NYCgov poverty rate 2011-2015 5-year average.
