### PR TITLE
Add borough land use map PDFs

### DIFF
--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -509,7 +509,8 @@
             <h4 class="subsection-header"><strong>Reference Maps</strong></h4>
             <div class="callout">
               <ul class="no-bullet">
-                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/landuse/{{model.borocdAcronymLowerCase}}_landuse.pdf">{{fa-icon "file-pdf-o"}} <strong>Land Use</strong></a></li>
+                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/landuse/{{model.borocdAcronymLowerCase}}_landuse.pdf">{{fa-icon "file-pdf-o"}} <strong>CD Land Use</strong></a></li>
+                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/boroughlanduse/{{model.borocdAcronymLowerCase}}_landuseprofile.pdf">{{fa-icon "file-pdf-o"}} <strong>Borough Land Use</strong></a></li>
                 <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/censustracts/{{model.borocdAcronymLowerCase}}_censustracts.pdf">{{fa-icon "file-pdf-o"}} <strong>Census Tracts</strong></a></li>
                 <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/basemaps/{{model.borocdAcronymLowerCase}}_basemap.pdf">{{fa-icon "file-pdf-o"}} <strong>Basemaps</strong></a></li>
                 <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/politicaldistricts/{{model.boroAcronymLowerCase}}_politicaldistricts.pdf">{{fa-icon "file-pdf-o"}} <strong>Political Districts</strong></a></li>


### PR DESCRIPTION
This PR adds links to borough land use map PDFs in the reference maps box of the resources section of each profile. 

Closes #436 
