### PR TITLE
764: use aliased view for zoning on carto

### DIFF
--- a/app/components/zoning-map.js
+++ b/app/components/zoning-map.js
@@ -2,7 +2,7 @@ import { computed } from '@ember/object'; // eslint-disable-line
 import FacilitiesSection from './facilities-section';
 import carto from '../utils/carto';
 
-const SQL = 'SELECT *, LEFT(zonedist, 2) as primaryzone FROM support_zoning_zd';
+const SQL = 'SELECT *, LEFT(zonedist, 2) as primaryzone FROM zoning_districts';
 const zdConfig = {
   id: 'zoning',
   type: 'fill',


### PR DESCRIPTION
Updates the zoning districts Carto query to use the new aliased view that has been created on Carto for the new Jan version.

More info about the view is available in the layers-api PR description: [NYCPlanning/labs-layers-api#106](https://github.com/NYCPlanning/labs-layers-api/pull/106)

Closes [NYCPlanning/labs-zola#764](https://github.com/NYCPlanning/labs-zola/issues/764)