### PR TITLE
542: Reorder building chart to fixed order

### DIFF
--- a/app/components/building-type-chart.js
+++ b/app/components/building-type-chart.js
@@ -28,6 +28,7 @@ const BuildingTypeChart = Component.extend(ResizeAware, {
         ${typeAbbrev}${modePrefix}06 AS "6",
         ${typeAbbrev}${modePrefix}07 AS "7",
         ${typeAbbrev}${modePrefix}08 AS "8",
+        ${typeAbbrev}${modePrefix}09 AS "9",
         ${typeAbbrev}${modePrefix}10 AS "10",
         ${typeAbbrev}${modePrefix}11 AS "11"
       FROM planninglabs.cd_floodplains
@@ -56,9 +57,6 @@ const BuildingTypeChart = Component.extend(ResizeAware, {
               value,
               value_pct,
             };
-          })
-          .sort((a, b) => { // eslint-disable-line
-            return a.value === b.value ? 0 : -(a.value > b.value) || 1;
           });
       });
   },


### PR DESCRIPTION
Reorder building chart to reflect fixed order rather than ordered by highest to lowest value. 

<img width="1045" alt="Screen Shot 2019-03-22 at 4 27 41 PM" src="https://user-images.githubusercontent.com/26672885/54851223-9a239b00-4cbf-11e9-8113-39f5f21ef06a.png">

Closes #542 