### PR TITLE
Update building and dwelling unit chart titles

### DIFF
--- a/app/templates/components/floodplain-charts.hbs
+++ b/app/templates/components/floodplain-charts.hbs
@@ -12,7 +12,11 @@
       {{#building-type-chart type='buildings' mode=mode borocd=model.borocd as |chart|}}
         <p>
           <span class="stat">
-            {{numeral-format (reduce (action 'sum') 0 (map-by 'value' (await chart.data))) '0,0'}}
+            {{#if (eq mode '100-yr')}}
+              {{model.dataprofile.fp_100_bldg}}
+            {{else}}
+              {{model.dataprofile.fp_500_bldg}}
+            {{/if}}
           </span>
           <span class="stat-footer">buildings are in the {{mode}} floodplain</span>
         </p>
@@ -36,7 +40,11 @@
       {{#building-type-chart type='units' mode=mode borocd=model.borocd as |chart|}}
         <p>
           <span class="stat">
-              {{numeral-format (reduce (action 'sum') 0 (map-by 'value' (await chart.data))) '0,0'}}
+            {{#if (eq mode '100-yr')}}
+              {{model.dataprofile.fp_100_resunits}}
+            {{else}}
+              {{model.dataprofile.fp_500_resunits}}
+            {{/if}}
           </span>
           <span class="stat-footer">dwelling units are in the {{mode}} floodplain</span>
         </p>

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -368,11 +368,6 @@
                       <td>{{if d.fp_500_mhhi (numeral-format d.fp_500_mhhi '$0,0') 'n/a'}}</td>
                     </tr>
                     <tr>
-                      <td>Open Space Area {{info-tooltip tip="based on MapPluto 15v1"}}</td>
-                      <td>{{if d.fp_100_openspace (concat d.fp_100_openspace ' sq mi') 'n/a'}}</td>
-                      <td>{{if d.fp_500_openspace (concat d.fp_500_openspace ' sq mi') 'n/a'}}</td>
-                    </tr>
-                    <tr>
                       <td>Total Units Owner Occupied {{info-tooltip tip=d.acs_tooltip_2}}</td>
                       <td>{{if d.fp_100_ownerocc (numeral-format d.fp_100_ownerocc '(0.0%)') 'n/a'}}</td>
                       <td>{{if d.fp_500_ownerocc (numeral-format d.fp_500_ownerocc '(0.0%)') 'n/a'}}</td>


### PR DESCRIPTION
- Update building and dwelling unit floodplain chart titles to reflect dataset table values rather than a sum of the chart values
- Remove open space variable
