### PR TITLE
573: handle null zap applicants

### DIFF
--- a/app/components/zap-list.js
+++ b/app/components/zap-list.js
@@ -17,8 +17,12 @@ export default Component.extend({
         const projects = res.data;
 
         projects.forEach((project) => {
-          const applicant = project.attributes.applicants.split(';')[0];
-          project.attributes.applicant = applicant; // eslint-disable-line
+          if (project.attributes.applicants) {
+            const applicant = project.attributes.applicants.split(';')[0];
+            project.attributes.applicant = applicant; // eslint-disable-line
+          } else {
+            project.attributes.applicant = 'Unknown Applicant'
+          }
         });
 
         return {


### PR DESCRIPTION
The ZAP project list component on Community District Profiles has been failing to load for several CDs, including Queens 1.

After some sleuthing, I discovered that the projects weren't loading because some projects in the CD have applicant=NULL which the app couldn't handle. I've updated the component to return 'Applicant Unknown' in those cases.

Closes #573 