### PR TITLE
596 extract tooltips

### DIFF
--- a/app/helpers/acs-floodplain-tooltip.js
+++ b/app/helpers/acs-floodplain-tooltip.js
@@ -1,0 +1,16 @@
+import { helper } from '@ember/component/helper';
+import { tooltipText } from '../tooltips/tooltip-text';
+
+export function buildTooltip(data) {
+  const {
+    puma,
+    cd_short_title,
+  } = data[0];
+
+  const acsFloodplain = tooltipText.acs.acsFloodplain(puma);
+  const cdApproximation = tooltipText.acs.cdApproximation(cd_short_title);
+
+  return acsFloodplain.concat(cdApproximation);
+}
+
+export default helper(buildTooltip);

--- a/app/helpers/acs-puma-cd-tooltip.js
+++ b/app/helpers/acs-puma-cd-tooltip.js
@@ -1,0 +1,20 @@
+import { helper } from '@ember/component/helper';
+import { tooltipText } from '../tooltips/tooltip-text';
+
+export function buildTooltip(data) {
+  const {
+    puma,
+    cd_short_title,
+    shared_puma,
+    shared_puma_cd,
+  } = data[0];
+
+  const pumaTooltip = tooltipText.acs.puma(puma);
+  const cdApproximation = tooltipText.acs.cdApproximation(cd_short_title);
+  const cdApproximationShared = tooltipText.acs.cdApproximationShared(cd_short_title, shared_puma_cd);
+
+  const concatenatedCdApproximation = shared_puma ? cdApproximationShared : cdApproximation;
+  return pumaTooltip.concat(concatenatedCdApproximation);
+}
+
+export default helper(buildTooltip);

--- a/app/helpers/census-floodplain-tooltip.js
+++ b/app/helpers/census-floodplain-tooltip.js
@@ -1,0 +1,12 @@
+import { helper } from '@ember/component/helper';
+import { tooltipText } from '../tooltips/tooltip-text';
+
+export function buildTooltip(data) {
+  const {
+    cd_short_title,
+  } = data[0];
+
+  return tooltipText.census.censusFloodplain(cd_short_title);
+}
+
+export default helper(buildTooltip);

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -54,7 +54,7 @@
               </div>
             </div>
 
-            <h4 class="subsection-header"><strong>Population by Age {{info-tooltip tip=d.acs_tooltip}}</strong></h4>
+            <h4 class="subsection-header"><strong>Population by Age {{info-tooltip tip=(acs-puma-cd-tooltip d)}}</strong></h4>
             <div class="callout">
               {{age-pyramid data=agePopDist}}
             </div>
@@ -82,7 +82,7 @@
               </div>
               <div class="cell large-6 xlarge-8">
 
-                <h4 class="subsection-header"><strong>Foreign-Born Population {{info-tooltip tip=d.acs_tooltip}}</strong></h4>
+                <h4 class="subsection-header"><strong>Foreign-Born Population {{info-tooltip tip=(acs-puma-cd-tooltip d)}}</strong></h4>
                 <div class="callout text-center">
                   <span class="stat">
                     {{numeral-format d.pct_foreign_born '0.0'}}%
@@ -93,7 +93,7 @@
               </div>
               <div class="cell xlarge-10">
 
-                <h4 class="subsection-header"><strong>Race &amp; Hispanic Origin {{info-tooltip tip=d.acs_tooltip}}</strong></h4>
+                <h4 class="subsection-header"><strong>Race &amp; Hispanic Origin {{info-tooltip tip=(acs-puma-cd-tooltip d)}}</strong></h4>
                 <div class="callout">
                   {{horizontal-bar data=racialProfile height=150 barLabel=false xMax=100}}
                 </div>
@@ -132,7 +132,7 @@
           {{#data.indicator class="indicator" name='Age Under 18'
                             column='under18_rate'
                             moe='moe_under18_rate'
-                            tip=d.acs_tooltip
+                            tip=(acs-puma-cd-tooltip d)
                             unit='%'
                             cd_stat=d.under18_rate
                             boro_stat=d.under18_rate_boro
@@ -142,7 +142,7 @@
           {{#data.indicator class="indicator" name='Age 65 & Over'
                             column='over65_rate'
                             moe='moe_over65_rate'
-                            tip=d.acs_tooltip
+                            tip=(acs-puma-cd-tooltip d)
                             unit='%'
                             cd_stat=d.over65_rate
                             boro_stat=d.over65_rate_boro
@@ -152,7 +152,7 @@
           {{#data.indicator class="indicator" name='Rent Burden'
                             column='pct_hh_rent_burd'
                             moe='moe_hh_rent_burd'
-                            tip=d.acs_tooltip
+                            tip=(acs-puma-cd-tooltip d)
                             unit='%'
                             cd_stat=d.pct_hh_rent_burd
                             boro_stat=d.pct_hh_rent_burd_boro
@@ -169,7 +169,7 @@
           {{#data.indicator class="indicator" name='Mean Commute to Work'
                             column='mean_commute'
                             moe='moe_mean_commute'
-                            tip=d.acs_tooltip
+                            tip=(acs-puma-cd-tooltip d)
                             cd_stat=d.mean_commute
                             boro_stat=d.mean_commute_boro
                             city_stat=d.mean_commute_nyc}}
@@ -196,7 +196,7 @@
           {{#data.indicator class="indicator" name='Educational Attainment'
                             column='pct_bach_deg'
                             moe='moe_bach_deg'
-                            tip=d.acs_tooltip
+                            tip=(acs-puma-cd-tooltip d)
                             unit='%'
                             cd_stat=d.pct_bach_deg
                             boro_stat=d.pct_bach_deg_boro
@@ -206,7 +206,7 @@
           {{#data.indicator class="indicator" name='Limited English Proficiency'
                             column='lep_rate'
                             moe='moe_lep_rate'
-                            tip=d.acs_tooltip
+                            tip=(acs-puma-cd-tooltip d)
                             unit='%'
                             cd_stat=d.lep_rate
                             boro_stat=d.lep_rate_boro
@@ -216,7 +216,7 @@
           {{#data.indicator class="indicator" name='Unemployment'
                             column='unemployment_cd'
                             moe='moe_unemployment_cd'
-                            tip=d.acs_tooltip
+                            tip=(acs-puma-cd-tooltip d)
                             unit='%'
                             cd_stat=d.unemployment_cd
                             boro_stat=d.unemployment_boro
@@ -337,7 +337,7 @@
                   </thead>
                   <tbody>
                     <tr>
-                      <td>Population (2010) {{info-tooltip tip=d.acs_tooltip_3}}</td>
+                      <td>Population (2010) {{info-tooltip tip=(census-floodplain-tooltip d)}}</td>
                       <td>
                         {{#if d.fp_500_pop}}
                           {{if (gte d.fp_100_pop 1000) (numeral-format d.fp_100_pop '0.0a') (numeral-format d.fp_100_pop '0')}}
@@ -359,7 +359,7 @@
                       <td>{{if d.fp_500_area (concat (numeral-format d.fp_500_area '0.00') ' sq mi') 'n/a'}}</td>
                     </tr>
                     <tr>
-                      <td>Median Household Income {{info-tooltip tip=d.acs_tooltip_2}}</td>
+                      <td>Median Household Income {{info-tooltip tip=(acs-floodplain-tooltip d)}}</td>
                       {{#if (eq d.fp_100_mhhi 200000)}}
                         <td>$200,000+</td>
                       {{else}}
@@ -368,22 +368,22 @@
                       <td>{{if d.fp_500_mhhi (numeral-format d.fp_500_mhhi '$0,0') 'n/a'}}</td>
                     </tr>
                     <tr>
-                      <td>% of Housing Units that are Owner-Occupied {{info-tooltip tip=d.acs_tooltip_2}}</td>
+                      <td>% of Housing Units that are Owner-Occupied {{info-tooltip tip=(acs-floodplain-tooltip d)}}</td>
                       <td class="{{if (lte d.fp_100_ownerocc_value 1000) 'unreliable'}}">{{if d.fp_100_ownerocc (numeral-format d.fp_100_ownerocc '(0.0%)') 'n/a'}}</td>
                       <td class="{{if (lte d.fp_500_ownerocc_value 1000) 'unreliable'}}">{{if d.fp_500_ownerocc (numeral-format d.fp_500_ownerocc '(0.0%)') 'n/a'}}</td>
                     </tr>
                     <tr>
-                      <td>% of Owner-Occupied Housing Units with Mortgages {{info-tooltip tip=d.acs_tooltip_2}}</td>
+                      <td>% of Owner-Occupied Housing Units with Mortgages {{info-tooltip tip=(acs-floodplain-tooltip d)}}</td>
                       <td class="{{if (lte d.fp_100_mortg_value 1000) 'unreliable'}}">{{if d.fp_100_permortg (numeral-format d.fp_100_permortg '(0.0%)') 'n/a'}}</td>
                       <td class="{{if (lte d.fp_500_mortg_value 1000) 'unreliable'}}">{{if d.fp_500_permortg (numeral-format d.fp_500_permortg '(0.0%)') 'n/a'}}</td>
                     </tr>
                     <tr>
-                      <td>% of Owner-Occupied Units that are Cost Burdened {{info-tooltip tip=d.acs_tooltip_2}}</td>
+                      <td>% of Owner-Occupied Units that are Cost Burdened {{info-tooltip tip=(acs-floodplain-tooltip d)}}</td>
                       <td class="{{if (lte d.fp_100_rent_burden_value 1000) 'unreliable'}}">{{if d.fp_100_rent_burden (numeral-format d.fp_100_rent_burden '(0.0%)') 'n/a'}}</td>
                       <td class="{{if (lte d.fp_500_rent_burden_value 1000) 'unreliable'}}">{{if d.fp_500_rent_burden (numeral-format d.fp_500_rent_burden '(0.0%)') 'n/a'}}</td>
                     </tr>
                     <tr>
-                      <td>% of Renter-Occupied Units that are Cost Burdened {{info-tooltip tip=d.acs_tooltip_2}}</td>
+                      <td>% of Renter-Occupied Units that are Cost Burdened {{info-tooltip tip=(acs-floodplain-tooltip d)}}</td>
                       <td class="{{if (lte d.fp_500_cost_burden_value 1000) 'unreliable'}}">{{if d.fp_100_cost_burden (numeral-format d.fp_100_cost_burden '(0.0%)') 'n/a'}}</td>
                       <td class="{{if (lte d.fp_500_cost_burden_value 1000) 'unreliable'}}">{{if d.fp_500_cost_burden (numeral-format d.fp_500_cost_burden '(0.0%)') 'n/a'}}</td>
                     </tr>

--- a/app/tooltips/tooltip-text.js
+++ b/app/tooltips/tooltip-text.js
@@ -1,0 +1,21 @@
+export const tooltipText = {
+  acs: {
+    puma(puma) {
+      return `American Community Survey 2014-2018 5-Year Estimates for PUMA ${puma}, `;
+    },
+    cdApproximation(cd_short_title) {
+      return `which is an approximation of ${cd_short_title}.`;
+    },
+    cdApproximationShared(cd_short_title, shared_puma_cd) {
+      return `which is an approximation of both ${cd_short_title} and ${shared_puma_cd}.`;
+    },
+    acsFloodplain(puma) {
+      return `American Community Survey (ACS) 2013-2017 5-year estimates for floodplain area within PUMA ${puma}, `; // which is an approximation of ${cd_short_title}
+    },
+  },
+  census: {
+    censusFloodplain(cd_short_title) {
+      return `2010 Census population counts for floodplain area within ${cd_short_title}.`;
+    },
+  },
+};

--- a/tests/integration/helpers/acs-floodplain-tooltip-test.js
+++ b/tests/integration/helpers/acs-floodplain-tooltip-test.js
@@ -1,0 +1,18 @@
+
+import { moduleForComponent, test } from 'ember-qunit';
+import { buildTooltip } from '../../../helpers/acs-floodplain-tooltip';
+
+moduleForComponent('acs-floodplain-tooltip', 'helper:acs-floodplain-tooltip', {
+  integration: true,
+});
+
+test('returns tooltip correctly', function(assert) {
+  const data = [{
+    puma: 444,
+    cd_short_title: 'Manhattan CD 2',
+  }];
+
+  const tooltip = buildTooltip(data);
+
+  assert.equal(tooltip, 'American Community Survey (ACS) 2013-2017 5-year estimates for floodplain area within PUMA 444, which is an approximation of Manhattan CD 2.');
+});

--- a/tests/integration/helpers/acs-puma-cd-tooltip-test.js
+++ b/tests/integration/helpers/acs-puma-cd-tooltip-test.js
@@ -1,0 +1,21 @@
+
+import { moduleForComponent, test } from 'ember-qunit';
+import { buildTooltip } from '../../../helpers/acs-puma-cd-tooltip';
+
+moduleForComponent('acs-puma-cd-tooltip', 'helper:acs-puma-cd-tooltip', {
+  integration: true,
+});
+
+// Replace this with your real tests.
+test('returns tooltip correctly', function(assert) {
+  const data = [{
+    puma: 444,
+    cd_short_title: 'Manhattan CD 2',
+    shared_puma: true,
+    shared_puma_cd: 'Manhattan CD 3',
+  }];
+
+  const tooltip = buildTooltip(data);
+
+  assert.equal(tooltip, 'American Community Survey 2014-2018 5-Year Estimates for PUMA 444, which is an approximation of both Manhattan CD 2 and Manhattan CD 3.');
+});

--- a/tests/integration/helpers/census-floodplain-tooltip-test.js
+++ b/tests/integration/helpers/census-floodplain-tooltip-test.js
@@ -1,0 +1,18 @@
+
+import { moduleForComponent, test } from 'ember-qunit';
+import { buildTooltip } from '../../../helpers/census-floodplain-tooltip';
+
+moduleForComponent('census-floodplain-tooltip', 'helper:census-floodplain-tooltip', {
+  integration: true,
+});
+
+// Replace this with your real tests.
+test('returns tooltip correctly', function(assert) {
+  const data = [{
+    cd_short_title: 'Manhattan CD 2',
+  }];
+
+  const tooltip = buildTooltip(data);
+
+  assert.equal(tooltip, '2010 Census population counts for floodplain area within Manhattan CD 2.');
+});


### PR DESCRIPTION
Create helpers to produce dynamic tooltips for acs and census data. These helpers replace static tooltips that were pulled from columns in the database. 

addresses #596 
