### PR TITLE
HOT FIX: update unemployment name to match july 2020 data update to fix bug

### DIFF
--- a/app/controllers/profile.js
+++ b/app/controllers/profile.js
@@ -63,7 +63,7 @@ export default Controller.extend({
 
   columns: [
     'poverty_rate',
-    'unemployment_cd',
+    'unemployment',
     'crime_count',
     'mean_commute',
     'pct_hh_rent_burd',
@@ -72,7 +72,7 @@ export default Controller.extend({
     'pct_served_parks',
     'moe_poverty_rate',
     'moe_bach_deg',
-    'moe_unemployment_cd',
+    'moe_unemployment',
     'moe_mean_commute',
     'moe_hh_rent_burd',
     'lep_rate',

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -214,11 +214,11 @@
             of residents self-identify as having <a href="https://www.census.gov/topics/population/language-use/about.html" target="_blank">limited English&nbsp;proficiency</a>
           {{/data.indicator}}
           {{#data.indicator class="indicator" name='Unemployment'
-                            column='unemployment_cd'
-                            moe='moe_unemployment_cd'
+                            column='unemployment'
+                            moe='moe_unemployment'
                             tip=(acs-puma-cd-tooltip d)
                             unit='%'
-                            cd_stat=d.unemployment_cd
+                            cd_stat=d.unemployment
                             boro_stat=d.unemployment_boro
                             city_stat=d.unemployment_nyc}}
             of the <a href="https://www.census.gov/topics/employment/labor-force.html" target="_blank">civilian labor force is unemployed</a>

--- a/public/data/cd_profile_data_dictionary.csv
+++ b/public/data/cd_profile_data_dictionary.csv
@@ -21,8 +21,8 @@ pct_bach_deg_boro,Percentage of residents 25 years or older that have earned a b
 moe_bach_deg_boro,Margin of error for corresponding data,American Community Survey 2012-2016 5-year estimates
 pct_bach_deg_nyc,Percentage of residents 25 years or older that have earned a bachelor's degree or higher in NYC,American Community Survey 2012-2016 5-year estimates
 moe_bach_deg_nyc,Margin of error for corresponding data,American Community Survey 2012-2016 5-year estimates
-unemployment_cd,Percentage of the civilian labor force that is unemployed in the PUMA that CD roughly matches,American Community Survey 2012-2016 5-year estimates
-moe_unemployment_cd,Margin of error for corresponding data,American Community Survey 2012-2016 5-year estimates
+unemployment,Percentage of the civilian labor force that is unemployed in the PUMA that CD roughly matches,American Community Survey 2012-2016 5-year estimates
+moe_unemployment,Margin of error for corresponding data,American Community Survey 2012-2016 5-year estimates
 unemployment_boro,Percentage of the civilian labor force that is unemployed in the CD's borough,American Community Survey 2012-2016 5-year estimates
 moe_unemployment_boro,Margin of error for corresponding data,American Community Survey 2012-2016 5-year estimates
 unemployment_nyc,Percentage of the civilian labor force that is unemployed in NYC,American Community Survey 2012-2016 5-year estimates


### PR DESCRIPTION
After July 2020 Community Profiles data update on labs-layers-api, discrepancies between old `unemployment_cd` vs new `unemployment` attribute names caused bugs in the app. This PR does a hot fix to get this bug sorted out.

Related to labs-layer-api issue [#194](https://github.com/NYCPlanning/labs-layers-api/issues/194)