### PR TITLE
hotfix: with new version of july 2020 dataset, unemployment field names were reverted back to old names

### DIFF
--- a/app/controllers/profile.js
+++ b/app/controllers/profile.js
@@ -63,7 +63,7 @@ export default Controller.extend({
 
   columns: [
     'poverty_rate',
-    'unemployment',
+    'unemployment_cd',
     'crime_count',
     'mean_commute',
     'pct_hh_rent_burd',
@@ -72,7 +72,7 @@ export default Controller.extend({
     'pct_served_parks',
     'moe_poverty_rate',
     'moe_bach_deg',
-    'moe_unemployment',
+    'moe_unemployment_cd',
     'moe_mean_commute',
     'moe_hh_rent_burd',
     'lep_rate',

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -214,11 +214,11 @@
             of residents self-identify as having <a href="https://www.census.gov/topics/population/language-use/about.html" target="_blank">limited English&nbsp;proficiency</a>
           {{/data.indicator}}
           {{#data.indicator class="indicator" name='Unemployment'
-                            column='unemployment'
-                            moe='moe_unemployment'
+                            column='unemployment_cd'
+                            moe='moe_unemployment_cd'
                             tip=(acs-puma-cd-tooltip d)
                             unit='%'
-                            cd_stat=d.unemployment
+                            cd_stat=d.unemployment_cd
                             boro_stat=d.unemployment_boro
                             city_stat=d.unemployment_nyc}}
             of the <a href="https://www.census.gov/topics/employment/labor-force.html" target="_blank">civilian labor force is unemployed</a>


### PR DESCRIPTION
New version of community profiles dataset was sent for the July 2020 update. This new dataset had the original unemployment field names. So this PR updates `unemployment` and `moe_unemployment` back to `unemployment_cd` and `moe_unemployment_cd`. 
