### PR TITLE
601: replace lot area percentages with new raw values from july 2020 data

### DIFF
--- a/app/utils/land-use-lookup.js
+++ b/app/utils/land-use-lookup.js
@@ -4,66 +4,79 @@ const LandUseLookup = (code) => {
       return {
         color: '#f4f455',
         description: '1 & 2 Family',
+        community_profiles_percent_field: 'pct_lot_area_res_1_2_family_bldg',
       };
     case 2:
       return {
         color: '#f7d496',
         description: 'Multifamily Walk-up',
+        community_profiles_percent_field: 'pct_lot_area_res_multifamily_walkup',
       };
     case 3:
       return {
         color: '#FF9900',
         description: 'Multifamily Elevator',
+        community_profiles_percent_field: 'pct_lot_area_res_multifamily_elevator',
       };
     case 4:
       return {
         color: '#f7cabf',
         description: 'Mixed Res. & Commercial',
+        community_profiles_percent_field: 'pct_lot_area_mixed_use',
       };
     case 5:
       return {
         color: '#ea6661',
         description: 'Commercial & Office',
+        community_profiles_percent_field: 'pct_lot_area_commercial_office',
       };
     case 6:
       return {
         color: '#d36ff4',
         description: 'Industrial & Manufacturing',
+        community_profiles_percent_field: 'pct_lot_area_industrial_manufacturing',
       };
     case 7:
       return {
         color: '#dac0e8',
         description: 'Transportation & Utility',
+        community_profiles_percent_field: 'pct_lot_area_transportation_utility',
       };
     case 8:
       return {
         color: '#5CA2D1',
         description: 'Public Facilities & Institutions',
+        community_profiles_percent_field: 'pct_lot_area_public_facility_institution',
       };
     case 9:
       return {
         color: '#8ece7c',
         description: 'Open Space & Outdoor Recreation',
+        community_profiles_percent_field: 'pct_lot_area_open_space',
       };
     case 10:
       return {
         color: '#bab8b6',
         description: 'Parking Facilities',
+        community_profiles_percent_field: 'pct_lot_area_parking',
       };
     case 11:
       return {
         color: '#5f5f60',
         description: 'Vacant Land',
+        community_profiles_percent_field: 'pct_lot_area_vacant',
       };
     case 12:
       return {
         color: '#5f5f60',
         description: 'Other',
+        community_profiles_percent_field: 'pct_lot_area_other_no_data',
       };
     default:
       return {
         color: '#5f5f60',
         description: 'Other',
+        community_profiles_percent_field: 'pct_lot_area_other_no_data',
       };
   }
 };


### PR DESCRIPTION
With the July 2020 data updates, there are new fields that provide raw values for lot area percentages that are included in the land use chart. This PR incorporates these new fields (which are sourced from the `community_district_profiles` dataset) into the app. 

First commit:
- include another SQL query that queries for the relevant fields on `community_district_profiles`
- within `data.then`, I added `communityProfilesData.then` to have access to these new fields (**NOTE**: this caused a major indentation, so if you're trying to see what changed within this section of the code, look at the second commit)
- `land-use-lookup.js` was updated to include the new community_district_profiles percent field names

Second commit:
- functions were created to dynamically grab the associated percent field values from `community_district_profiles`
- a new sorting method was added to sort the bars on the d3 graph
- `d.percent` was updated everywhere in the file to be `lotAreaPercent(d)`

Addresses #601 