### PR TITLE
767: update projects section based on zap-search updates

### DIFF
--- a/app/components/zap-list.js
+++ b/app/components/zap-list.js
@@ -8,7 +8,7 @@ export default Component.extend({
   projects: computed('district', function() {
     const zapAcronym = this.get('district.zapAcronym');
 
-    const URL = `https://zap-api.planninglabs.nyc/projects?community-districts[]=${zapAcronym}&dcp_publicstatus[]=Filed&dcp_publicstatus[]=In Public Review&page=1`;
+    const URL = `https://zap-api-production.herokuapp.com/projects?community-districts[]=${zapAcronym}&dcp_publicstatus[]=Filed&dcp_publicstatus[]=In Public Review&page=1`;
 
     return fetch(URL)
       .then(res => res.json())
@@ -21,13 +21,21 @@ export default Component.extend({
             const applicant = project.attributes.applicants.split(';')[0];
             project.attributes.applicant = applicant; // eslint-disable-line
           } else {
-            project.attributes.applicant = 'Unknown Applicant'
+            project.attributes.applicant = 'Unknown Applicant';
           }
         });
 
+        const projectsUnderscored = projects.map(project => ({
+          dcp_publicstatus: project.attributes['dcp-publicstatus'],
+          dcp_name: project.attributes['dcp-name'],
+          dcp_projectname: project.attributes['dcp-projectname'],
+          dcp_ulurp_nonulurp: project.attributes['dcp-ulurp-nonulurp'],
+          applicant: project.attributes.applicant,
+        }));
+
         return {
-          filed: projects.filter(d => d.attributes.dcp_publicstatus_simp === 'Filed'),
-          inPublicReview: projects.filter(d => d.attributes.dcp_publicstatus_simp === 'In Public Review'),
+          filed: projectsUnderscored.filter(d => d.dcp_publicstatus === 'Filed'),
+          inPublicReview: projectsUnderscored.filter(d => d.dcp_publicstatus === 'In Public Review'),
         };
       });
   }),

--- a/app/models/district.js
+++ b/app/models/district.js
@@ -13,6 +13,14 @@ const acronymCrosswalk = {
   'Staten Island': 'SI',
 };
 
+const zapAcronymCrosswalk = {
+  Bronx: 'X',
+  Brooklyn: 'K',
+  Manhattan: 'M',
+  Queens: 'Q',
+  'Staten Island': 'R',
+};
+
 export default DS.Model.extend({
   borocd: DS.attr('number'),
   boro: DS.attr('string'),
@@ -22,7 +30,7 @@ export default DS.Model.extend({
     return `${acronym}${cd}`;
   }),
   zapAcronym: computed('boro', function() {
-    const acronym = acronymCrosswalk[this.get('boro')];
+    const acronym = zapAcronymCrosswalk[this.get('boro')];
     const cd = numeral(this.get('cd')).format('00');
     return `${acronym}${cd}`;
   }),

--- a/app/templates/components/zap-list.hbs
+++ b/app/templates/components/zap-list.hbs
@@ -7,8 +7,8 @@
       <ul class="no-bullet xlarge-2-column">
         {{#each resolvedProjects.filed as |project|}}
           <li class="list-item-padded">
-            <a href = "https://zap.planning.nyc.gov/projects/{{project.attributes.dcp_name}}" target="_blank">{{fa-icon "external-link"}}&nbsp;<strong>{{if project.attributes.dcp_projectname project.attributes.dcp_projectname "No Name"}}</strong></a>
-            <small class="list--link-meta">{{project.attributes.applicant}} | {{project.attributes.dcp_ulurp_nonulurp}}</small>
+            <a href = "https://zap.planning.nyc.gov/projects/{{project.dcp_name}}" target="_blank">{{fa-icon "external-link"}}&nbsp;<strong>{{if project.dcp_projectname project.dcp_projectname "No Name"}}</strong></a>
+            <small class="list--link-meta">{{project.applicant}} | {{project.dcp_ulurp_nonulurp}}</small>
           </li>
         {{/each}}
       </ul>
@@ -21,8 +21,8 @@
       <ul class="no-bullet xlarge-2-column">
         {{#each resolvedProjects.inPublicReview as |project|}}
           <li class="list-item-padded">
-            <a href = "https://zap.planning.nyc.gov/projects/{{project.attributes.dcp_name}}" target="_blank">{{fa-icon "external-link"}}&nbsp;<strong>{{if project.attributes.dcp_projectname project.attributes.dcp_projectname "No Name"}}</strong></a>
-            <small class="list--link-meta">{{project.attributes.applicant}} | {{project.attributes.dcp_ulurp_nonulurp}}</small>
+            <a href = "https://zap.planning.nyc.gov/projects/{{project.dcp_name}}" target="_blank">{{fa-icon "external-link"}}&nbsp;<strong>{{if project.dcp_projectname project.dcp_projectname "No Name"}}</strong></a>
+            <small class="list--link-meta">{{project.applicant}} | {{project.dcp_ulurp_nonulurp}}</small>
           </li>
         {{/each}}
       </ul>


### PR DESCRIPTION
**Summary**
Previously the Projects section was grabbing data from an outdated zap-api source. This meant that certain projects were being incorrectly filtered into the "Filed" and "In Public Review" sections. This PR updates the zap-api source to point to the new and updated link. 

**Technical Summary**
- replace outdated zap-api source link with new & updated one
- update computed property that was incorrectly renaming borough acronyms in `district` model
- remap the new zap-api incoming data to use underscores instead of hyphens (only remapped the 5 attributes that were being used in the template) in `zap-list.js`
- reformat the `zap-list.hbs` template accordingly based on new remapping

Addresses [AB#767](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/767)
