### PR TITLE
Bug/9380 failed zap api request

### DIFF
--- a/app/components/zap-list.js
+++ b/app/components/zap-list.js
@@ -10,24 +10,9 @@ export default Component.extend({
     try {
       const zapAcronym = this.get('district.zapAcronym');
       /* eslint-disable-next-line no-unused-vars */
-      const zapApi = ENV.environment === 'production' ? ENV.ZAP_PRODUCTION_API : ENV.ZAP_STAGING_API;
+      const zapApi = ENV.ZAP_API;
 
-      const URL = `https://zap-api-production.herokuapp.com/projects?community-districts[]=${zapAcronym}`;
-
-      fetch(URL)
-        .then(res => res.json())
-        .then((res) => {
-          console.log('response', res);
-          // get the data object, return object with arrays of projects grouped by dcp_publicstatus_simp
-          const projects = res.data;
-          console.log('response data', res.data);
-
-          const filed = projects.filter(d => d.attributes['dcp-publicstatus'] === 'Filed');
-          const inPublicReview = projects.filter(d => d.attributes['dcp-publicstatus'] === 'In Public Review');
-
-          console.log('filed', filed);
-          console.log('inPublicReview', inPublicReview);
-        });
+      const URL = `${zapApi}/projects?community-districts[]=${zapAcronym}`;
 
       return fetch(URL)
         .then(res => res.json())

--- a/app/models/district.js
+++ b/app/models/district.js
@@ -6,11 +6,11 @@ import numeral from 'numeral';
 import neighborhoodsCrosswalk from '../utils/nabesCrosswalk';
 
 const acronymCrosswalk = {
-  Bronx: 'BX',
-  Brooklyn: 'BK',
-  Manhattan: 'MN',
-  Queens: 'QN',
-  'Staten Island': 'SI',
+  Bronx: 'X',
+  Brooklyn: 'K',
+  Manhattan: 'M',
+  Queens: 'Q',
+  'Staten Island': 'R',
 };
 
 export default DS.Model.extend({

--- a/app/templates/components/zap-list.hbs
+++ b/app/templates/components/zap-list.hbs
@@ -7,7 +7,7 @@
       <ul class="no-bullet xlarge-2-column">
         {{#each resolvedProjects.filed as |project|}}
           <li class="list-item-padded">
-            <a href = "https://zap.planning.nyc.gov/projects/{{project.attributes.dcp_name}}" target="_blank">{{fa-icon "external-link"}}&nbsp;<strong>{{if project.attributes.dcp_projectname project.attributes.dcp_projectname "No Name"}}</strong></a>
+            <a href = "https://zap.planning.nyc.gov/projects/{{project.attributes.dcp-name}}" target="_blank">{{fa-icon "external-link"}}&nbsp;<strong>{{if project.attributes.dcp-projectname project.attributes.dcp-projectname "No Name"}}</strong></a>
             <small class="list--link-meta">{{project.attributes.applicant}} | {{project.attributes.dcp_ulurp_nonulurp}}</small>
           </li>
         {{/each}}
@@ -21,7 +21,7 @@
       <ul class="no-bullet xlarge-2-column">
         {{#each resolvedProjects.inPublicReview as |project|}}
           <li class="list-item-padded">
-            <a href = "https://zap.planning.nyc.gov/projects/{{project.attributes.dcp_name}}" target="_blank">{{fa-icon "external-link"}}&nbsp;<strong>{{if project.attributes.dcp_projectname project.attributes.dcp_projectname "No Name"}}</strong></a>
+            <a href = "https://zap.planning.nyc.gov/projects/{{project.attributes.dcp-name}}" target="_blank">{{fa-icon "external-link"}}&nbsp;<strong>{{if project.attributes.dcp-projectname project.attributes.dcp-projectname "No Name"}}</strong></a>
             <small class="list--link-meta">{{project.attributes.applicant}} | {{project.attributes.dcp_ulurp_nonulurp}}</small>
           </li>
         {{/each}}

--- a/config/dotenv.js
+++ b/config/dotenv.js
@@ -6,7 +6,7 @@ const path = require('path');
 /* eslint-disable-next-line no-unused-vars */
 module.exports = function(env) {
   return {
-    clientAllowedKeys: ['ZAP_API_STAGING_URL', 'ZAP_API_PRODUCTION_URL'],
+    clientAllowedKeys: ['ZAP_API_URL'],
     fastbootAllowedKeys: [],
     failOnMissingKey: false,
     path: path.join(path.dirname(__dirname), '.env'),

--- a/config/environment.js
+++ b/config/environment.js
@@ -46,8 +46,7 @@ module.exports = function(environment) {
         style: 'https://layers-api.planninglabs.nyc/v1/base/style.json',
       },
     },
-    ZAP_STAGING_API: process.env.ZAP_API_STAGING_URL,
-    ZAP_PRODUCTION_API: process.env.ZAP_API_PRODUCTION_URL,
+    ZAP_API: process.env.ZAP_API_URL,
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,10 +5,10 @@ command = "yarn build --environment=staging"
 command = "yarn build --environment=production"
 
 [context.develop]
-ZAP_API_STAGING_URL = "https://zap-api-staging.herokuapp.com"
+ZAP_API_URL = "https://zap-api-staging.herokuapp.com"
 
 [context.staging]
-ZAP_API_STAGING_URL = "https://zap-api-staging.herokuapp.com"
+ZAP_API_URL = "https://zap-api-staging.herokuapp.com"
 
 [context.production]
-ZAP_API_PRODUCTION_URL = "https://zap-api-production.herokuapp.com"
+ZAP_API_URL = "https://zap-api-production.herokuapp.com"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,10 +5,10 @@ command = "yarn build --environment=staging"
 command = "yarn build --environment=production"
 
 [context.develop]
-ZAP_API_URL = "https://zap-api-staging.herokuapp.com"
+environment = { ZAP_API_URL = "https://zap-api-staging.herokuapp.com" }
 
 [context.staging]
-ZAP_API_URL = "https://zap-api-staging.herokuapp.com"
+environment = { ZAP_API_URL = "https://zap-api-staging.herokuapp.com" }
 
 [context.production]
-ZAP_API_URL = "https://zap-api-production.herokuapp.com"
+environment = { ZAP_API_URL = "https://zap-api-production.herokuapp.com" }


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR
Projects tab list of filed and in public review developments are populated with the correct data.
     - clean up to do to:
      - remove logging
      - point the dev environment back to the zap staging api after the staging api is brought back on par with prod
     - updated the `acronymCrosswalk` in  `district.js` to the single letter boro as the api expects to receive (at some point, the dataset may have changed)
     - updated a 2 pairs of variables from underscore separated to dash separated as the api expects to receive.

Closes [#9380](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/9380)
