### PR TITLE
10510 created resource specific mapping to previous 2 char boro abbreviations

### DIFF
--- a/app/models/district.js
+++ b/app/models/district.js
@@ -13,6 +13,14 @@ const acronymCrosswalk = {
   'Staten Island': 'R',
 };
 
+const resourcesAcronymCrosswalk = {
+  Bronx: 'BX',
+  Brooklyn: 'BK',
+  Manhattan: 'MN',
+  Queens: 'QN',
+  'Staten Island': 'SI',
+};
+
 export default DS.Model.extend({
   borocd: DS.attr('number'),
   boro: DS.attr('string'),
@@ -28,6 +36,11 @@ export default DS.Model.extend({
   }),
   borocdAcronymLowerCase: computed('boro', function() {
     const acronym = acronymCrosswalk[this.get('boro')].toLowerCase();
+    const cd = numeral(this.get('cd')).format('00');
+    return `${acronym}${cd}`;
+  }),
+  resourcesBoroCdAcronymLowerCase: computed('boro', function() {
+    const acronym = resourcesAcronymCrosswalk[this.get('boro')].toLowerCase();
     const cd = numeral(this.get('cd')).format('00');
     return `${acronym}${cd}`;
   }),

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -505,11 +505,11 @@
             <h4 class="subsection-header"><strong>Reference Maps</strong></h4>
             <div class="callout">
               <ul class="no-bullet">
-                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/landuse/{{model.borocdAcronymLowerCase}}_landuse.pdf">{{fa-icon "file-pdf-o"}} <strong>CD Land Use</strong></a></li>
-                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/boroughlanduse/{{model.boroAcronymLowerCase}}_landuseprofile.pdf">{{fa-icon "file-pdf-o"}} <strong>Borough Land Use</strong></a></li>
-                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/censustracts/{{model.borocdAcronymLowerCase}}_censustracts.pdf">{{fa-icon "file-pdf-o"}} <strong>Census Tracts</strong></a></li>
-                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/basemaps/{{model.borocdAcronymLowerCase}}_basemap.pdf">{{fa-icon "file-pdf-o"}} <strong>Basemaps</strong></a></li>
-                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/politicaldistricts/{{model.boroAcronymLowerCase}}_politicaldistricts.pdf">{{fa-icon "file-pdf-o"}} <strong>Political Districts</strong></a></li>
+                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/landuse/{{model.resourcesBoroCdAcronymLowerCase}}_landuse.pdf">{{fa-icon "file-pdf-o"}} <strong>CD Land Use</strong></a></li>
+                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/boroughlanduse/{{model.resourcesBoroCdAcronymLowerCase}}_landuseprofile.pdf">{{fa-icon "file-pdf-o"}} <strong>Borough Land Use</strong></a></li>
+                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/censustracts/{{model.resourcesBoroCdAcronymLowerCase}}_censustracts.pdf">{{fa-icon "file-pdf-o"}} <strong>Census Tracts</strong></a></li>
+                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/basemaps/{{model.resourcesBoroCdAcronymLowerCase}}_basemap.pdf">{{fa-icon "file-pdf-o"}} <strong>Basemaps</strong></a></li>
+                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/politicaldistricts/{{model.resourcesBoroCdAcronymLowerCase}}_politicaldistricts.pdf">{{fa-icon "file-pdf-o"}} <strong>Political Districts</strong></a></li>
               </ul>
             </div>
 
@@ -530,7 +530,7 @@
             </div>
             <h4 class="subsection-header"><strong>Summary Community District Profile {{info-tooltip tip="Download a one-page PDF version of this community district profile designed for printing."}}</strong></h4>
             <div class="callout">
-              <a class="button small hollow expanded" target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/static-profiles/{{model.borocdAcronymLowerCase}}_profile.pdf">{{fa-icon "file-pdf-o"}} <strong>{{model.boro}} Community District {{model.cd}} Summary Profile</strong></a>
+              <a class="button small hollow expanded" target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/static-profiles/{{model.resourcesBoroCdAcronymLowerCase}}_profile.pdf">{{fa-icon "file-pdf-o"}} <strong>{{model.boro}} Community District {{model.cd}} Summary Profile</strong></a>
             </div>
           </div>
           <div class="cell medium-5 xlarge-4">


### PR DESCRIPTION
#### This PR
A previous bug fix [PR#669](https://github.com/NYCPlanning/labs-community-profiles/pull/669) (related [PR#668](https://github.com/NYCPlanning/labs-community-profiles/pull/668) ) updated the acronyms used in `app/components/zap-list.js` from two characters to a single character to match the column values the new dataset values. 

Unfortunately, the both the Resources and the Summary Community District Profile links still use the two character boro abbreviations so the above PR broke link functionality. This PR recreates the two character boro abbreviations required to link to the correct resources. I also added a additional method to use in the Resources and Summary Community District Profile links.

#### Closes:
[AB#10510](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/10510)
