### PR TITLE
Bug 10510 resource reference maps links broken related fix

### DIFF
--- a/app/models/district.js
+++ b/app/models/district.js
@@ -49,7 +49,7 @@ export default DS.Model.extend({
     return `${acronym}`;
   }),
   boroAcronymLowerCase: computed('boro', function() {
-    const acronym = acronymCrosswalk[this.get('boro')].toLowerCase();
+    const acronym = resourcesAcronymCrosswalk[this.get('boro')].toLowerCase();
     return `${acronym}`;
   }),
   healthProfileLink: computed('boro', function() {


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

#### This PR
Bug related to [PR#671](https://github.com/NYCPlanning/labs-community-profiles/pull/671), this is a fix for the  NYC Community Districts Health Profile Link. Update `boroAcronymLowerCase` to use 2 character boro abbreviations object.

```
# districts.js lines 55-61
healthProfileLink: computed('boro', function() {
    const boroAcronymLowerCase = this.get('boroAcronymLowerCase');
    let cd = this.get('cd');
    if (boroAcronymLowerCase === 'si' || boroAcronymLowerCase === 'qn') {
      cd = numeral(cd).format('00');
    }
    return `https://www1.nyc.gov/assets/doh/downloads/pdf/data/2015chp-${boroAcronymLowerCase}${cd}.pdf`;

# profiles.hbs
<a href="{{model.healthProfileLink}}">{{fa-icon "file-pdf-o"}} <strong>{{model.boro}} Community District {{model.cd}} Health Profile</strong></a>
```

#### Closes
[AB#10510](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/10510)
