### PR TITLE
update land use and political districts links to use lowercase boro abbreviations

### DIFF
--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -506,10 +506,10 @@
             <div class="callout">
               <ul class="no-bullet">
                 <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/landuse/{{model.resourcesBoroCdAcronymLowerCase}}_landuse.pdf">{{fa-icon "file-pdf-o"}} <strong>CD Land Use</strong></a></li>
-                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/boroughlanduse/{{model.resourcesBoroCdAcronymLowerCase}}_landuseprofile.pdf">{{fa-icon "file-pdf-o"}} <strong>Borough Land Use</strong></a></li>
+                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/boroughlanduse/{{model.boroAcronymLowerCase}}_landuseprofile.pdf">{{fa-icon "file-pdf-o"}} <strong>Borough Land Use</strong></a></li>
                 <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/censustracts/{{model.resourcesBoroCdAcronymLowerCase}}_censustracts.pdf">{{fa-icon "file-pdf-o"}} <strong>Census Tracts</strong></a></li>
                 <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/basemaps/{{model.resourcesBoroCdAcronymLowerCase}}_basemap.pdf">{{fa-icon "file-pdf-o"}} <strong>Basemaps</strong></a></li>
-                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/politicaldistricts/{{model.resourcesBoroCdAcronymLowerCase}}_politicaldistricts.pdf">{{fa-icon "file-pdf-o"}} <strong>Political Districts</strong></a></li>
+                <li class="list-item-padded"><a target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/politicaldistricts/{{model.boroAcronymLowerCase}}_politicaldistricts.pdf">{{fa-icon "file-pdf-o"}} <strong>Political Districts</strong></a></li>
               </ul>
             </div>
 


### PR DESCRIPTION
The Borough Land Use and Political Districts are not Community District specific documents, [PR#671](https://github.com/NYCPlanning/labs-community-profiles/pull/671) erroneously changed them to boro abbreviation and community district number  in error, breaking the links.

#### Related PRs:
[PR#671](https://github.com/NYCPlanning/labs-community-profiles/pull/671)
[PR#672](https://github.com/NYCPlanning/labs-community-profiles/pull/672)

#### Closes 
[AB#10510](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/10510)