### PR TITLE
10579 – Fix borocdAcronym to match CD Needs Statement files

### DIFF
--- a/app/models/district.js
+++ b/app/models/district.js
@@ -25,7 +25,7 @@ export default DS.Model.extend({
   borocd: DS.attr('number'),
   boro: DS.attr('string'),
   borocdAcronym: computed('boro', function() {
-    const acronym = acronymCrosswalk[this.get('boro')];
+    const acronym = resourcesAcronymCrosswalk[this.get('boro')];
     const cd = numeral(this.get('cd')).format('00');
     return `${acronym}${cd}`;
   }),


### PR DESCRIPTION
Resolves AB[#10579](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20T?workitem=10579).

The borocdAcronym was being computed using the [acronymCrosswalk](https://github.com/NYCPlanning/labs-community-profiles/blob/ede13bfb2410199b60a1b9d112cd83bb07be28fe/app/models/district.js#L8-L14) object instead of [resourcesAcronymCrosswalk](https://github.com/NYCPlanning/labs-community-profiles/blob/ede13bfb2410199b60a1b9d112cd83bb07be28fe/app/models/district.js#L16-L22). This resulted in partial matches for Bronx and Brooklyn profiles (e.g. X01 would still match to BX01) however in the cases of Manhattan, Queens, and Staten Island the different borocodes broke the filter search (e.g. M01 would **not** match to MN01).

Manhattan
![Screen Shot 2022-09-19 at 12 16 33 PM](https://user-images.githubusercontent.com/43344288/191065329-4bc612a0-973e-4eef-8a28-4e7adfaeaef3.png)

Queens
![Screen Shot 2022-09-19 at 12 21 51 PM](https://user-images.githubusercontent.com/43344288/191065400-cbed2a4a-33ff-482b-a016-a455ea16c874.png)

Staten Island
![Screen Shot 2022-09-19 at 12 22 16 PM](https://user-images.githubusercontent.com/43344288/191065472-0ad5f202-b9db-40a6-9aa4-94a02e104a46.png)
