### PR TITLE
matcher as static method

### DIFF
--- a/app/components/navigation-dropdown.js
+++ b/app/components/navigation-dropdown.js
@@ -48,8 +48,8 @@ export default class extends Component {
   ).restartable())
   debounceTerms;
 
-  matcher(value, searchTerm) {
-    if (this.get(value, 'constructor.modelName') === 'address') {
+  static matcher(value, searchTerm) {
+    if (get(value, 'constructor.modelName') === 'address') {
       return true;
     }
 


### PR DESCRIPTION
# Description
When originally linting `navigation-dropdown.js`, I received a [class-methods-use-this](https://eslint.org/docs/latest/rules/class-methods-use-this) error. I interpreted the linting error as pointing out that `get(value, 'constructor.modelName')` needed a `this` lookup. After making this change, the `get` was no longer referencing the function imported from `ember/object`, causing an error.

This PR correctly interrupts the linting error, which points out that methods without `this` references can be static. It also reverts the change of using `this` for `get`.

## Tickets
Closes AB#13484
