### PR TITLE
14194 Add Matomo to Community Profiles

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -181,6 +181,10 @@ export default Controller.extend({
         eventAction: 'Click',
         eventLabel: `${boro} ${cd}`,
         eventValue: borocd,
+        category: 'Navigation Map',
+        action: 'Click',
+        label: `${boro} ${cd}`,
+        value: borocd,
       });
     },
     handleMousemove(e) {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -183,7 +183,7 @@ export default Controller.extend({
         eventValue: borocd,
         category: 'Navigation Map',
         action: 'Click',
-        label: `${boro} ${cd}`,
+        name: `${boro} ${cd}`,
         value: borocd,
       });
     },

--- a/app/controllers/profile.js
+++ b/app/controllers/profile.js
@@ -105,5 +105,16 @@ export default Controller.extend({
         });
       });
     },
+    trackAnchorLink(anchor) {
+      const metrics = this.get('metrics');
+      metrics.trackEvent({
+        eventCategory: 'Anchor Link',
+        eventAction: 'Click',
+        eventLabel: `${anchor}`,
+        category: 'Anchor Link',
+        action: 'Click',
+        name: `${anchor}`,
+      });
+    },
   },
 });

--- a/app/router.js
+++ b/app/router.js
@@ -18,9 +18,8 @@ export default class Router extends EmberRouter {
 
   _trackPage() {
     scheduleOnce('afterRender', this, () => {
-      const page = this.get('url');
+      const page = this.get('currentURL') || this.get('url');
       const title = this.getWithDefault('currentRouteName', 'unknown');
-
       get(this, 'metrics').trackPage({ page, title });
     });
   }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -26,6 +26,10 @@ export default Route.extend(SetMapBounds, {
         eventAction: 'Click',
         eventLabel: `${boro} ${borocd % 100}`,
         eventValue: borocd,
+        category: 'Navigation Dropdown',
+        action: 'Click',
+        label: `${boro} ${borocd % 100}`,
+        value: borocd,
       });
 
       const modelName = district.get('constructor.modelName');

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -28,7 +28,7 @@ export default Route.extend(SetMapBounds, {
         eventValue: borocd,
         category: 'Navigation Dropdown',
         action: 'Click',
-        label: `${boro} ${borocd % 100}`,
+        name: `${boro} ${borocd % 100}`,
         value: borocd,
       });
 

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -9,12 +9,12 @@
       </h1>
       <div class="section-menu hide-for-print">
         <ul class="menu">
-          <li><a href='#indicators'>Indicators</a></li>
-          <li><a href='#built-environment'>Built Environment</a></li>
-          <li><a href='#floodplain'>Floodplain</a></li>
-          <li><a href='#community-board'>Community Board</a></li>
-          <li><a href='#projects'>Projects</a></li>
-          <li><a href='#resources'>Resources</a></li>
+          <li><a href='#indicators' onclick={{action 'trackAnchorLink' 'Indicators'}}>Indicators</a></li>
+          <li><a href='#built-environment' onclick={{action 'trackAnchorLink' 'Built Environment'}}>Built Environment</a></li>
+          <li><a href='#floodplain' onclick={{action 'trackAnchorLink' 'Floodplain'}}>Floodplain</a></li>
+          <li><a href='#community-board' onclick={{action 'trackAnchorLink' 'Community Board'}}>Community Board</a></li>
+          <li><a href='#projects' onclick={{action 'trackAnchorLink' 'Projects'}}>Projects</a></li>
+          <li><a href='#resources' onclick={{action 'trackAnchorLink' 'Resources'}}>Resources</a></li>
         </ul>
       </div>
     </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -15,7 +15,7 @@ module.exports = function(environment) {
     metricsAdapters: [
       {
         name: 'MatomoTagManager',
-        environments: ['development', 'production', 'test'],
+        environments: ['development', 'production', 'test', 'staging'],
         config: {
           matomoUrl: 'matomo-poc-f47265605236.herokuapp.com',
           containerId: 'aXgWxtkC',

--- a/config/environment.js
+++ b/config/environment.js
@@ -17,7 +17,7 @@ module.exports = function(environment) {
         name: 'MatomoTagManager',
         environments: ['development', 'production', 'test', 'staging'],
         config: {
-          matomoUrl: 'matomo-poc-f47265605236.herokuapp.com',
+          matomoUrl: 'matomo.planninglabs.nyc',
           containerId: 'aXgWxtkC',
         },
       },

--- a/config/environment.js
+++ b/config/environment.js
@@ -14,6 +14,14 @@ module.exports = function(environment) {
 
     metricsAdapters: [
       {
+        name: 'MatomoTagManager',
+        environments: ['development', 'production', 'test'],
+        config: {
+          matomoUrl: 'matomo-poc-f47265605236.herokuapp.com',
+          containerId: 'aXgWxtkC',
+        },
+      },
+      {
         name: 'GoogleAnalytics',
         environments: ['development', 'production'],
         config: {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-mapbox-gl": "^1.2.1",
     "ember-math-helpers": "^2.2.3",
-    "dcp-ember-metrics": "https://github.com/dhochbaum-dcp/dcp-ember-metrics#rename",
+    "dcp-ember-metrics": "https://github.com/dhochbaum-dcp/dcp-ember-metrics",
     "ember-page-title": "^6.2.2",
     "ember-power-select": "^5.0.4",
     "ember-qunit": "^5.1.5",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-mapbox-gl": "^1.2.1",
     "ember-math-helpers": "^2.2.3",
-    "ember-metrics": "^2.0.0-beta.2",
+    "dcp-ember-metrics": "https://github.com/dhochbaum-dcp/dcp-ember-metrics#rename",
     "ember-page-title": "^6.2.2",
     "ember-power-select": "^5.0.4",
     "ember-qunit": "^5.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5969,6 +5969,14 @@ date-time@^2.1.0:
   dependencies:
     time-zone "^1.0.0"
 
+"dcp-ember-metrics@https://github.com/dhochbaum-dcp/dcp-ember-metrics#rename":
+  version "2.0.0-beta.1"
+  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#43be538168aef8d3675859892afdd58076bd51b7"
+  dependencies:
+    broccoli-funnel "^3.0.2"
+    ember-cli-babel "^7.26.6"
+    ember-cli-typescript "^5.1.1"
+
 debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -7219,15 +7227,6 @@ ember-maybe-in-element@^2.0.3:
     ember-cli-babel "^7.26.11"
     ember-cli-htmlbars "^6.1.1"
     ember-cli-version-checker "^5.1.2"
-
-ember-metrics@^2.0.0-beta.2:
-  version "2.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/ember-metrics/-/ember-metrics-2.0.0-beta.2.tgz#f621e11386c61ba1b117748ef34b887dab8ad644"
-  integrity sha512-vKPVfY4IIO5KszCsExUkxwqUgnuiUpvacNhzudms4JKZy0zeoU5tyXscPngW8vpqcGF6q8ZbaNTxw1OIVKd+xw==
-  dependencies:
-    broccoli-funnel "^3.0.2"
-    ember-cli-babel "^7.26.6"
-    ember-cli-typescript "^5.1.1"
 
 ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5971,7 +5971,7 @@ date-time@^2.1.0:
 
 "dcp-ember-metrics@https://github.com/dhochbaum-dcp/dcp-ember-metrics#rename":
   version "2.0.0-beta.1"
-  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#43be538168aef8d3675859892afdd58076bd51b7"
+  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#6395581b2dae2b02595341e5b9baa4ccba60a1c8"
   dependencies:
     broccoli-funnel "^3.0.2"
     ember-cli-babel "^7.26.6"


### PR DESCRIPTION
This PR adds our self-hosted Matomo Tag Manager to Community Profiles

Closes [AB#14194](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/14194)

~~Tracking of anchor links should be added as a future task.~~
