### PR TITLE
14350 Updated dcp-ember-metrics

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5971,7 +5971,7 @@ date-time@^2.1.0:
 
 "dcp-ember-metrics@https://github.com/dhochbaum-dcp/dcp-ember-metrics":
   version "1.0.0"
-  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#0f6311e538cf2c3517596daf0058e9fe7d9fc3b4"
+  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#32c076eab242c34fc87245b6ad039e06c3dd7585"
   dependencies:
     broccoli-funnel "^3.0.2"
     ember-cli-babel "^7.26.6"


### PR DESCRIPTION
This PR updates the version of dcp-ember-metrics to a version which checks to see whether _paq exists before attempting to use it, resolving any issues created by adblockers.

Closes [AB#14350](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/14350)
