### PR TITLE
Update map min height to match page-content

### DIFF
--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -62,7 +62,7 @@ html, body {
       bottom: 0;
       left: 0;
       width: 33.33333%;
-      height: calc(100vh);
+      min-height: calc(100vh - 75px);
     }
 
     @include breakpoint(xlarge) {


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR changes the map height to match the`page-content` height since they are both elements in the same main container. 

Current:
<img width="1896" alt="image" src="https://github.com/NYCPlanning/labs-community-profiles/assets/7049943/9527eef0-bc84-4c33-9b6e-f411e8d9f9ee">

With this PR:
<img width="1896" alt="image" src="https://github.com/NYCPlanning/labs-community-profiles/assets/7049943/36588522-ed31-4910-a4ff-c4421ff63033">

This way we can have the map and page-content elements be the same height without having to manually set positions for individual map controls. 

This PR doesn't address:
<details>
  <summary>1. Unfinished box shadow:</summary>
<img width="620" alt="Screenshot 2024-01-05 at 2 50 04 PM" src="https://github.com/NYCPlanning/labs-community-profiles/assets/7049943/15151cd2-e345-41ec-be8b-b4f97397cf91">
</details>
<details>
  <summary>2. Search bar blocking info in mobile view:</summary>
<img width="350" alt="Screenshot 2024-01-05 at 2 51 47 PM" src="https://github.com/NYCPlanning/labs-community-profiles/assets/7049943/7defa67d-e182-4e38-9c2e-ac7680871e22">
</details>

Closes #703 
