### PR TITLE
709 Add Link to Glossary

### DIFF
--- a/app/templates/components/needs-statements.hbs
+++ b/app/templates/components/needs-statements.hbs
@@ -8,5 +8,8 @@
   {{#unless showAll}}
     <button class="button small hollow no-margin" onclick={{action 'toggleList'}}><strong>Show All Needs Statements</strong></button>
   {{/unless}}
+    <a href="https://docs.google.com/viewer?url=https://github.com/NYCPlanning/labs-cd-needs-statements/raw/master//Community_District_Needs_Glossary.pdf" target="_blank">
+      <button class="button small hollow no-margin"><FaIcon @icon="file-pdf" />&nbsp;<strong>Glossary</strong></button>
+    </a>
 </div>
 {{yield}}


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds a link to a glossary next to the CD Needs Statements.
<img width="536" alt="image" src="https://github.com/NYCPlanning/labs-community-profiles/assets/61206501/3e618508-1658-4578-8767-39eed41b9922">

Closes #709 
