### PR TITLE
14 File Size Fix

### DIFF
--- a/app/components/needs-statements.js
+++ b/app/components/needs-statements.js
@@ -3,7 +3,7 @@ import Component from '@ember/component';
 import fetch from 'fetch';
 
 const statementsPath = 'https://api.github.com/repos/NYCPlanning/labs-cd-needs-statements/git/trees/master?recursive=1';
-const download = 'https://docs.google.com/viewer?url=https://github.com/NYCPlanning/labs-cd-needs-statements/raw/master/';
+const download = 'https://github.com/NYCPlanning/labs-cd-needs-statements/raw/master/';
 
 function stripDirectory(string) {
   const loc = string.lastIndexOf('/');


### PR DESCRIPTION
This PR makes CD Needs statements download directly, rather than google docs preview.  This is necessary because some of the PDFs are over 25mb, which causes an error with the google docs preview and prevents the user from seeing the PDF contents.

Closes [labs-cd-needs-statements#14](https://github.com/NYCPlanning/labs-cd-needs-statements/issues/14)
