### PR TITLE
Update Matomo to use cloud hosting instead of self-hosted.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -27,7 +27,7 @@
       _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
       (function() {
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.async=true; g.src='https://matomo.planninglabs.nyc/js/container_aXgWxtkC.js'; s.parentNode.insertBefore(g,s);
+        g.async=true; g.src='https://cdn.matomo.cloud/nycplanning.matomo.cloud/container_bssTxW2v.js'; s.parentNode.insertBefore(g,s);
       })();
     </script>
     <!-- End Matomo Tag Manager -->

--- a/config/environment.js
+++ b/config/environment.js
@@ -17,8 +17,8 @@ module.exports = function(environment) {
         name: 'MatomoTagManager',
         environments: ['development', 'production', 'test', 'staging'],
         config: {
-          matomoUrl: 'matomo.planninglabs.nyc',
-          containerId: 'aXgWxtkC',
+          matomoUrl: 'nycplanning.matomo.cloud',
+          containerId: 'bssTxW2v',
         },
       },
       {


### PR DESCRIPTION
This PR updates Matomo to use cloud hosting instead of self-hosted.

Part of [ae-private#36](https://github.com/NYCPlanning/ae-private/issues/36)